### PR TITLE
Removed missing reference SystemCenter

### DIFF
--- a/SCOM API/Controllers/SCOMMaintenanceController.cs
+++ b/SCOM API/Controllers/SCOMMaintenanceController.cs
@@ -8,7 +8,6 @@ using Microsoft.EnterpriseManagement;
 using Microsoft.EnterpriseManagement.Common;
 using Microsoft.EnterpriseManagement.Monitoring;
 using System.Web;
-using Microsoft.SystemCenter.OperationsManagerV10.Commands;
 using Microsoft.EnterpriseManagement.Configuration;
 using Newtonsoft.Json;
 using System.Collections.ObjectModel;


### PR DESCRIPTION
The reference to `Microsoft.SystemCenter.OperationsManagerV10.Commands` was missing, wasn't used, and caused the build to fail. Perhaps not the right solution, but was an easy fix.